### PR TITLE
Escribir los Dockerfile y el docker-compose.

### DIFF
--- a/docker/coor/Dockerfile
+++ b/docker/coor/Dockerfile
@@ -1,0 +1,47 @@
+FROM ubuntu:22.04
+
+RUN apt-get update && apt-get install -y \
+    wireguard \
+    iproute2 \
+    iputils-ping \
+    nano \
+    vim \
+    curl \
+    iperf3 \
+    netcat-openbsd \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /etc/wireguard
+
+RUN echo '#!/bin/bash\n\
+    wg genkey | tee /etc/wireguard/private.key | wg pubkey > /etc/wireguard/public.key\n\
+    echo "PRIVATE KEY:"\n\
+    cat /etc/wireguard/private.key\n\
+    echo "PUBLIC KEY:"\n\
+    cat /etc/wireguard/public.key\n\
+    ' > /usr/local/bin/generar-llaves && chmod +x /usr/local/bin/generar-llaves
+
+
+RUN echo "[Interface]" > /etc/wireguard/wg0.conf && \
+    echo "Address = 10.0.0.1/24" >> /etc/wireguard/wg0.conf && \
+    echo "PrivateKey = SUSTITUIR_POR_PRIVATE_KEY" >> /etc/wireguard/wg0.conf && \
+    echo "ListenPort = 51820" >> /etc/wireguard/wg0.conf && \
+    echo "" >> /etc/wireguard/wg0.conf && \
+    echo "#[Peer]" >> /etc/wireguard/wg0.conf && \
+    echo "#PublicKey = SUSTITUIR_POR_PUBLIC_KEY_DEL_PEER1" >> /etc/wireguard/wg0.conf && \
+    echo "#AllowedIPs = 10.0.0.2/32" >> /etc/wireguard/wg0.conf && \
+    echo "#" >> /etc/wireguard/wg0.conf && \
+    echo "#[Peer]" >> /etc/wireguard/wg0.conf && \
+    echo "#PublicKey = SUSTITUIR_POR_PUBLIC_KEY_DEL_PEER2" >> /etc/wireguard/wg0.conf && \
+    echo "#AllowedIPs = 10.0.0.3/32" >> /etc/wireguard/wg0.conf && \
+    echo "#" >> /etc/wireguard/wg0.conf && \
+    echo "#[Peer]" >> /etc/wireguard/wg0.conf && \
+    echo "#PublicKey = SUSTITUIR_POR_PUBLIC_KEY_DEL_PEER3" >> /etc/wireguard/wg0.conf && \
+    echo "#AllowedIPs = 10.0.0.4/32" >> /etc/wireguard/wg0.conf && \
+    echo "#" >> /etc/wireguard/wg0.conf && \
+    echo "#[Peer]" >> /etc/wireguard/wg0.conf && \
+    echo "#PublicKey = SUSTITUIR_POR_PUBLIC_KEY_DEL_PEER4" >> /etc/wireguard/wg0.conf && \
+    echo "#AllowedIPs = 10.0.0.5/32" >> /etc/wireguard/wg0.conf
+
+CMD ["sleep", "infinity"]

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,27 @@
+services:
+  edge:
+    build: ./edge
+    container_name: edge
+    cap_add:
+      - NET_ADMIN
+      - SYS_MODULE
+    command: sleep infinity
+    restart: unless-stopped
+
+  sensor1:
+    build: ./sensor
+    container_name: sensor1
+    cap_add:
+      - NET_ADMIN
+      - SYS_MODULE
+    command: sleep infinity
+    restart: unless-stopped
+
+  sensor2:
+    build: ./sensor
+    container_name: sensor2
+    cap_add:
+      - NET_ADMIN
+      - SYS_MODULE
+    command: sleep infinity
+    restart: unless-stopped

--- a/docker/edge/Dockerfile
+++ b/docker/edge/Dockerfile
@@ -1,0 +1,37 @@
+FROM ubuntu:22.04
+
+RUN apt-get update && apt-get install -y \
+    wireguard \
+    iproute2 \
+    iputils-ping \
+    nano \
+    vim \
+    curl \
+    iperf3 \
+    netcat-openbsd \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /etc/wireguard
+
+RUN echo '#!/bin/bash\n\
+    wg genkey | tee /etc/wireguard/private.key | wg pubkey > /etc/wireguard/public.key\n\
+    echo "PRIVATE KEY:"\n\
+    cat /etc/wireguard/private.key\n\
+    echo "PUBLIC KEY:"\n\
+    cat /etc/wireguard/public.key\n\
+    ' > /usr/local/bin/generar-llaves && chmod +x /usr/local/bin/generar-llaves
+
+
+RUN echo "[Interface]" > /etc/wireguard/wg0.conf && \
+    echo "Address = SUSTITUIR_POR_IP_ASIGNADA" >> /etc/wireguard/wg0.conf && \
+    echo "PrivateKey = SUSTITUIR_POR_PRIVATE_KEY" >> /etc/wireguard/wg0.conf && \
+    echo "ListenPort = 51820" >> /etc/wireguard/wg0.conf && \
+    echo "" >> /etc/wireguard/wg0.conf && \
+    echo "[Peer]" >> /etc/wireguard/wg0.conf && \
+    echo "PublicKey = SUSTITUIR_POR_PUBLIC_KEY_DEL_COORD" >> /etc/wireguard/wg0.conf && \
+    echo "Endpoint = SUSTITUIR_POR_IP_DEL_CONTENEDOR_COORD:51820" >> /etc/wireguard/wg0.conf && \
+    echo "AllowedIPs = 10.0.0.1/32" >> /etc/wireguard/wg0.conf && \
+    echo "PersistentKeepalive = 25" >> /etc/wireguard/wg0.conf
+
+CMD ["sleep", "infinity"]

--- a/docker/sensor/Dockerfile
+++ b/docker/sensor/Dockerfile
@@ -1,0 +1,36 @@
+FROM ubuntu:22.04
+
+RUN apt-get update && apt-get install -y \
+    wireguard \
+    iproute2 \
+    iputils-ping \
+    nano \
+    vim \
+    curl \
+    iperf3 \
+    netcat-openbsd \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/*
+
+RUN mkdir -p /etc/wireguard
+
+RUN echo '#!/bin/bash\n\
+    wg genkey | tee /etc/wireguard/private.key | wg pubkey > /etc/wireguard/public.key\n\
+    echo "PRIVATE KEY:"\n\
+    cat /etc/wireguard/private.key\n\
+    echo "PUBLIC KEY:"\n\
+    cat /etc/wireguard/public.key\n\
+    ' > /usr/local/bin/generar-llaves && chmod +x /usr/local/bin/generar-llaves
+
+
+RUN echo "[Interface]" > /etc/wireguard/wg0.conf && \
+    echo "Address = SUSTITUIR_POR_IP_ASIGNADA" >> /etc/wireguard/wg0.conf && \
+    echo "PrivateKey = SUSTITUIR_POR_PRIVATE_KEY" >> /etc/wireguard/wg0.conf && \
+    echo "" >> /etc/wireguard/wg0.conf && \
+    echo "[Peer]" >> /etc/wireguard/wg0.conf && \
+    echo "PublicKey = SUSTITUIR_POR_PUBLIC_KEY_DEL_EDGE" >> /etc/wireguard/wg0.conf && \
+    echo "Endpoint = SUSTITUIR_POR_IP_DEL_CONTENEDOR_EDGE:51820" >> /etc/wireguard/wg0.conf && \
+    echo "AllowedIPs = SUSTITUIR_POR_IP_DEL_EDGE_EN_LA_VPN/32" >> /etc/wireguard/wg0.conf && \
+    echo "PersistentKeepalive = 25" >> /etc/wireguard/wg0.conf
+
+CMD ["sleep", "infinity"]


### PR DESCRIPTION
Escribir un Dockerfile por cada tipo de contenedor (coor, edge y sensor), además de un docker-compose.yml, el cual se encarga de crear tres contenedores: uno de ellos es de tipo edge, los dos restantes son de tipo sensor.